### PR TITLE
fix #9: conflicts are now correctly generated

### DIFF
--- a/chatbot/launch.py
+++ b/chatbot/launch.py
@@ -60,7 +60,7 @@ def insert_documents(data):
                         None)
 
         if prod_doc and temp_doc:
-            if temp_doc["content"] != prod_doc["content"]:
+            if not temp_doc["content"] == prod_doc["content"]:
                 title = temp_doc["content"]["title"]
                 conflicts.append({"conflict_id": idx,
                                   "title": title})
@@ -100,9 +100,6 @@ def insert_documents(data):
     # Removes duplicates
     factory.get_collection(unknown_col).create_index([("query_text", 1)],
                                                      unique=True)
-
-    if not conflicts:
-        factory.get_collection(conflict_col).drop()
 
     return conflicts
 


### PR DESCRIPTION
Fixes #9. There was an error in how old content and new content were compared.
The conflict collection is also not dropped for each content update, fixing the issue where all old conflicts are wiped. 

Tested and validated manually. 