### PR TITLE
Feat/#55 json payload + session

### DIFF
--- a/chatbot/api/server.py
+++ b/chatbot/api/server.py
@@ -14,7 +14,7 @@ app = Flask(__name__)
 app.register_blueprint(v1_dialog_api)
 app.register_blueprint(v1_web_api)
 
-api = Api(app, version='2.0')
+api = Api(app, version='2.1')
 api.add_namespace(v2_api)
 
 CORS(app)

--- a/chatbot/api/v2/api.py
+++ b/chatbot/api/v2/api.py
@@ -9,7 +9,7 @@ from chatbot.model.model_factory import ModelFactory
 from chatbot.util.config_util import Config
 
 
-api = Namespace('v2', description='Chatbot APIv2')
+api = Namespace('v2', description='Chatbot APIv2.1')
 
 
 factory = ModelFactory.get_instance()

--- a/chatbot/api/v2/api.py
+++ b/chatbot/api/v2/api.py
@@ -1,3 +1,5 @@
+import random
+
 import chatbot.api.v2.models as models
 
 from flask_restplus import Namespace, Resource, fields, abort, reqparse
@@ -75,6 +77,10 @@ content_collection_model = api.model('ContentCol', {
 
 unknown_query_model = api.model('UnknownQuery', {
     'query_text': fields.String
+})
+
+session_model = api.model('Session', {
+    'session': fields.Integer
 })
 
 
@@ -261,6 +267,22 @@ class UnknownQueries(Resource):
             abort(404, 'Unknown query not found')
 
 
+class Session(Resource):
+    @api.marshal_with(session_model)
+    def get(self):
+        return {"session": random.randint(1000, 9999)}
+
+    @api.marshal_with(session_model)
+    @api.response(400, 'Session already closed or timed out')
+    def delete(self, session):
+        # TODO: Verify if session is valid
+        try:
+            session = int(session)
+            return {"session": session}
+        except:
+            abort(400, 'Session ID not an integer.')
+
+
 api.add_resource(HelloWorld, '/', methods=['GET'])
 
 api.add_resource(ResponseJSON, '/response/', methods=['GET'])
@@ -280,3 +302,7 @@ api.add_resource(UnknownQueries, '/unknown_queries/', methods=['GET'])
 api.add_resource(UnknownQueries,
                  '/unknown_queries/<unknown_query>/',
                  methods=['DELETE'])
+
+api.add_resource(Session, '/session/', methods=['GET'])
+api.add_resource(Session, '/session/<session>/', methods=['DELETE'])
+

--- a/chatbot/api/v2/models.py
+++ b/chatbot/api/v2/models.py
@@ -5,12 +5,12 @@ handler = QueryHandler()
 
 
 class Response(object):
-    def __init__(self, user_input, style, source):
+    def __init__(self, user_input, style, source, session=None):
         self.user_input = user_input
         self.response = handler.get_response(self.user_input, style, source)
         self.style = style
         self.source = source
-
+        self.session = session
 
 class Conflict(object):
     def __init__(self, conflict_id, title):


### PR DESCRIPTION
Adds dummy-session end-point GET: `/v2/session/` and DELETE: `/v2/session/{session}/`.

GET: `/v2/response/` now accepts JSON-payload for input, and requires a session ID. 